### PR TITLE
Re-positioned trigger of serial-monitor-connected event.

### DIFF
--- a/js/compilerflasher.js
+++ b/js/compilerflasher.js
@@ -1201,8 +1201,6 @@ compilerflasher = function (loadFiles) {
                 return;
             }
 
-            selfCf.eventManager.fire('serial-monitor-connected');
-
             var $baudRates = $('#cb_cf_baud_rates');
             var speed = $baudRates.find('option:selected').val();
             var $ports = $("#cb_cf_ports");
@@ -1231,6 +1229,7 @@ compilerflasher = function (loadFiles) {
             $("#serial_monitor_content").fadeIn(300);
 
             this.connected = true;
+            selfCf.eventManager.fire('serial-monitor-connected');
             // When in app no status messages appear when connection establishes
             this.serialMonitorInitialized = selfCf.useApp;
 


### PR DESCRIPTION
### Changes:
- Re-positioned the triggering of serial-monitor-connected event
  - Event is not triggering when no board is connected
  - Pause/Resume button depends on the event and went in a wrong state when no board was connected
